### PR TITLE
Support trending gifs and return cancelable task when searching

### DIFF
--- a/ziphy/ZiphyClient.swift
+++ b/ziphy/ZiphyClient.swift
@@ -30,7 +30,7 @@ public typealias ZiphsCallBack = (_ success:Bool, _ ziphs:[Ziph], _ error:Error?
 public typealias ZiphByIdCallBack = (_ success:Bool, _ ziphId:String, _ error:Error?)->()
 public typealias ZiphyImageCallBack = (_ success:Bool, _ image:ZiphyImageRep?, _ ziph:Ziph, _ data:Data?, _ error:Error?) -> ()
 
-@objc public class ZiphyClient : NSObject {
+@objc public final class ZiphyClient : NSObject {
     
     
     open static var logLevel:ZiphyLogLevel = ZiphyLogLevel.error
@@ -53,13 +53,13 @@ public typealias ZiphyImageCallBack = (_ success:Bool, _ image:ZiphyImageRep?, _
             gifsEndpoint:gifsEndpoint)
     }
     
-    open func trending(_ callBackQueue:DispatchQueue = DispatchQueue.main, resultsLimit:Int = 25, offset:Int, onCompletion: @escaping ZiphsCallBack) -> CancelableTask? {
+    public func trending(_ callBackQueue:DispatchQueue = DispatchQueue.main, resultsLimit:Int = 25, offset:Int, onCompletion: @escaping ZiphsCallBack) -> CancelableTask? {
         
         let eitherRequest = self.requestGenerator.trendingRequestWithParameters(resultsLimit: resultsLimit, offset: offset)
         return  performZiphListRequest(eitherRequest: eitherRequest, onCompletion: onCompletion, callBackQueue: callBackQueue)
     }
     
-    open func search(_ callBackQueue:DispatchQueue = DispatchQueue.main, term:String, resultsLimit:Int = 25, offset:Int = 0, onCompletion: @escaping ZiphsCallBack) -> CancelableTask? {
+    public func search(_ callBackQueue:DispatchQueue = DispatchQueue.main, term:String, resultsLimit:Int = 25, offset:Int = 0, onCompletion: @escaping ZiphsCallBack) -> CancelableTask? {
         
         let eitherRequest = self.requestGenerator.searchRequestWithParameters(term, resultsLimit:resultsLimit, offset:offset)
         return performZiphListRequest(eitherRequest: eitherRequest, onCompletion: onCompletion, callBackQueue: callBackQueue)
@@ -106,7 +106,7 @@ public typealias ZiphyImageCallBack = (_ success:Bool, _ image:ZiphyImageRep?, _
         return searchTask
     }
     
-    open func randomGif(_ callBackQueue:DispatchQueue = DispatchQueue.main,
+    public func randomGif(_ callBackQueue:DispatchQueue = DispatchQueue.main,
         onCompletion:@escaping ZiphByIdCallBack) {
         
         let eitherRequest = self.requestGenerator.randomRequests()
@@ -139,7 +139,7 @@ public typealias ZiphyImageCallBack = (_ success:Bool, _ image:ZiphyImageRep?, _
         }
     }
     
-    open func gifsById(_ callBackQueue:DispatchQueue = DispatchQueue.main,
+    public func gifsById(_ callBackQueue:DispatchQueue = DispatchQueue.main,
         ids:[String],
         onCompletion:@escaping ZiphsCallBack) {
         
@@ -175,7 +175,7 @@ public typealias ZiphyImageCallBack = (_ success:Bool, _ image:ZiphyImageRep?, _
         
     }
     
-    open func fetchImage(_ callBackQueue:DispatchQueue = DispatchQueue.main,
+    public func fetchImage(_ callBackQueue:DispatchQueue = DispatchQueue.main,
         ziph:Ziph,
         imageType:ZiphyImageType,
         onCompletion:@escaping ZiphyImageCallBack) {

--- a/ziphy/ZiphyImageFetcher.swift
+++ b/ziphy/ZiphyImageFetcher.swift
@@ -103,7 +103,7 @@ public typealias SingleZiphCallBack = (_ imageData:Data?, _ ziph:Ziph?,  _ error
             
             self.offset = justZiphs.count
             
-            self.ziphyClient.search(callBackQueue,
+            _ = self.ziphyClient.search(callBackQueue,
                 term: self.term,
                 resultsLimit: self.resultsLimit,
                 offset:self.offset) { (success, ziphs, error) in

--- a/ziphy/ZiphyRequestGenerator.swift
+++ b/ziphy/ZiphyRequestGenerator.swift
@@ -27,6 +27,7 @@ struct ZiphyRequestGenerator {
     let apiVersionPath:String
     let searchEndpoint:String
     let randomEndpoint:String
+    let trendingEndpoint:String
     let gifsEndpoint:String
     
     fileprivate func requestWithParameters(_ endPoint:String, query:String? = nil) -> Either<Error, URLRequest> {
@@ -53,6 +54,10 @@ struct ZiphyRequestGenerator {
                 code: ZiphyError.malformedURL.rawValue,
                 userInfo:[NSLocalizedDescriptionKey:invalidURL + " is not a valid URL"]))
         }
+    }
+    
+    func trendingRequestWithParameters(resultsLimit:Int, offset:Int) -> Either<Error, URLRequest> {
+        return self.requestWithParameters(self.trendingEndpoint, query: "limit=\(resultsLimit)&offset=\(offset)")
     }
     
     func searchRequestWithParameters(_ term:String, resultsLimit:Int, offset:Int) -> Either<Error, URLRequest> {

--- a/ziphyTests/ZiphyPaginationControllerTests.swift
+++ b/ziphyTests/ZiphyPaginationControllerTests.swift
@@ -61,9 +61,7 @@ class ZiphyPaginationControllerTests: ZiphyTestCase {
             expectation.fulfill()
             
             if (success) {
-                
-                let _ = paginationController?.ziphs?.first
-                XCTAssertTrue((paginationController?.ziphs?.count)! > 0 , "Paged fetched but no ziphs")
+                XCTAssertTrue(paginationController!.ziphs.count > 0 , "Paged fetched but no ziphs")
             }
             else {
                 
@@ -74,7 +72,7 @@ class ZiphyPaginationControllerTests: ZiphyTestCase {
         self.paginationController.fetchBlock = self.fetchBlockForSearch(paginationController, searchTerm: "cat", resultsLimit: 25)
         self.paginationController.completionBlock = completionBlock
         
-        self.paginationController.fetchNewPage()
+        _ = self.paginationController.fetchNewPage()
         
         waitForExpectations(timeout: 10, handler:nil)
     }
@@ -87,11 +85,11 @@ class ZiphyPaginationControllerTests: ZiphyTestCase {
         self.paginationController.completionBlock = { [weak self](success, error) in
             
             if (success && (self?.paginationController.totalPagesFetched)! < 3) {
-                self?.paginationController.fetchNewPage()
+                _ = self?.paginationController.fetchNewPage()
             }
             else if (success && self?.paginationController.totalPagesFetched == 3) {
                 expectation.fulfill()
-                XCTAssertTrue(self?.paginationController.ziphs?.count == 25*3, "Did not fetch enough gifs")
+                XCTAssertTrue(self?.paginationController.ziphs.count == 25*3, "Did not fetch enough gifs")
             }
             else {
                 expectation.fulfill()
@@ -99,7 +97,7 @@ class ZiphyPaginationControllerTests: ZiphyTestCase {
             }
         }
         
-        self.paginationController.fetchNewPage()
+        _ = self.paginationController.fetchNewPage()
         
         waitForExpectations(timeout: 10, handler:nil)
     }
@@ -112,7 +110,7 @@ class ZiphyPaginationControllerTests: ZiphyTestCase {
         self.paginationController.completionBlock = { [weak self](success, error) in
             
             if (success) {
-                self?.paginationController.fetchNewPage()
+                _ = self?.paginationController.fetchNewPage()
             }
             else if (!success) {
                 expectation.fulfill()
@@ -123,7 +121,7 @@ class ZiphyPaginationControllerTests: ZiphyTestCase {
             }
         }
         
-        self.paginationController.fetchNewPage()
+        _ = self.paginationController.fetchNewPage()
         
         waitForExpectations(timeout: 10, handler:nil)
     

--- a/ziphyTests/ZiphyTestCase.swift
+++ b/ziphyTests/ZiphyTestCase.swift
@@ -33,10 +33,6 @@ class GiphyRequester : ZiphyURLRequester {
     }
     
     func doRequest(_ request: URLRequest, completionHandler: @escaping ((Data?, URLResponse?, Error?) -> Void)) -> URLSessionDataTask {
-        
-        
-        //        if let originalURL:URL = request.url {
-        
         var urlString = request.url!.absoluteString
         urlString = urlString+"&api_key=\(self.apiKey)"
         
@@ -45,14 +41,6 @@ class GiphyRequester : ZiphyURLRequester {
         let task = self.searchSession.dataTask(with: newURL!, completionHandler: completionHandler)
         task.resume()
         return task
-//        }
-//        else {
-//            completionHandler(nil, nil,NSError(domain: "requester.error",
-//                code: 1,
-//                userInfo:[NSLocalizedDescriptionKey:"Request"]))
-//        }
-        
-//        return nil
     }
 }
 

--- a/ziphyTests/ZiphyTestCase.swift
+++ b/ziphyTests/ZiphyTestCase.swift
@@ -32,24 +32,27 @@ class GiphyRequester : ZiphyURLRequester {
         self.searchSession = URLSession(configuration: URLSessionConfiguration.default)
     }
     
-    @objc func doRequest(_ request: URLRequest, completionHandler: @escaping ((Data?, URLResponse?, Error?) -> Void)) {
+    func doRequest(_ request: URLRequest, completionHandler: @escaping ((Data?, URLResponse?, Error?) -> Void)) -> URLSessionDataTask {
         
-        if let originalURL:URL = request.url {
-            
-            var urlString = originalURL.absoluteString
-            urlString = urlString+"&api_key=\(self.apiKey)"
-            
-            let newURL = URL(string: urlString)
-            
-            let task = self.searchSession.dataTask(with: newURL!, completionHandler: completionHandler)
-            task.resume()
-        }
-        else {
-            completionHandler(nil, nil,NSError(domain: "requester.error",
-                code: 1,
-                userInfo:[NSLocalizedDescriptionKey:"Request"]))
-        }
         
+        //        if let originalURL:URL = request.url {
+        
+        var urlString = request.url!.absoluteString
+        urlString = urlString+"&api_key=\(self.apiKey)"
+        
+        let newURL = URL(string: urlString)
+        
+        let task = self.searchSession.dataTask(with: newURL!, completionHandler: completionHandler)
+        task.resume()
+        return task
+//        }
+//        else {
+//            completionHandler(nil, nil,NSError(domain: "requester.error",
+//                code: 1,
+//                userInfo:[NSLocalizedDescriptionKey:"Request"]))
+//        }
+        
+//        return nil
     }
 }
 

--- a/ziphyTests/ziphyTests.swift
+++ b/ziphyTests/ziphyTests.swift
@@ -46,7 +46,7 @@ class ziphyTests: ZiphyTestCase {
         
         let expectation = self.expectation(description: "did return some results")
         
-        self.ziphyClient.search(term:"cat", resultsLimit: 10, offset: 0) { (success, gifs, error) -> () in
+        _ = self.ziphyClient.search(term:"cat", resultsLimit: 10, offset: 0) { (success, gifs, error) -> () in
             
             XCTAssert(success)
             expectation.fulfill()
@@ -57,11 +57,29 @@ class ziphyTests: ZiphyTestCase {
         }
     }
     
+    func testThatTrendingReturnsResults() {
+        
+        //Set up
+        
+        
+        let expectation = self.expectation(description: "did return some results")
+        
+        _ = self.ziphyClient.trending(resultsLimit: 10, offset: 0) { (success, gifs, error) -> () in
+            XCTAssert(success)
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 20) { (error) in
+            
+        }
+    }
+    
+    
     func testThatFunkyCharsWork() {
         
         let expectation = self.expectation(description: "did return some results")
         
-        self.ziphyClient.search(term:"cat\"=\"#%/<>?@\\^`{|}&:#[]@$'+;", resultsLimit: 10, offset: 0) { (success, gifs, error) -> () in
+        _ = self.ziphyClient.search(term:"cat\"=\"#%/<>?@\\^`{|}&:#[]@$'+;", resultsLimit: 10, offset: 0) { (success, gifs, error) -> () in
             
             XCTAssert(success)
             expectation.fulfill()


### PR DESCRIPTION
## Why the change
For the updated version of the Giphy feature we need to support searching for gifs and displaying trending gifs. We also need a way to cancel ongoing searches when the search term changes quickly.

# What changed
- Added method for retrieving trending gifs
- `search` and `trending` methods returns a `CancelableTask`
- `ZiphySearchResultsController` has been adapted to allow multiple searches.