### PR TITLE
Fix/zios 9807 return ziphs in callback

### DIFF
--- a/ziphy/ZiphyPaginationController.swift
+++ b/ziphy/ZiphyPaginationController.swift
@@ -20,7 +20,7 @@
 import Foundation
 
 
-public typealias SuccessOrErrorCallback = (_ success:Bool, _ error:Error?)->()
+public typealias SuccessOrErrorCallback = (_ success:Bool, _ ziphs:[Ziph], _ error:Error?)->()
 public typealias FetchBlock = (_ offset:Int)-> CancelableTask?
 
 public class ZiphyPaginationController {
@@ -72,8 +72,6 @@ public class ZiphyPaginationController {
             self.offset = self.ziphs.count
         }
         
-        performOnQueue(self.callBackQueue){
-            self.completionBlock?(success, error)
-        }
+        self.completionBlock?(success, self.ziphs, error)
     }
 }

--- a/ziphy/ZiphySearchResultsController.swift
+++ b/ziphy/ZiphySearchResultsController.swift
@@ -19,19 +19,18 @@
 
 import Foundation
 
-
-
-@objc public class ZiphySearchResultsController : NSObject {
-    
-    public var ziphyClient : ZiphyClient?
-    public var results : [Ziph] {
-        let ziphs = self.paginationController?.ziphs ?? []
-        
-        return ziphs.filter({
+extension Array where Element:Ziph {
+    fileprivate func filteredResults(maxImageSize: Int) -> [Ziph] {
+        return self.filter({
             guard let size = $0.ziphyImages[ZiphyClient.fromZiphyImageTypeToString(.downsized)]?.size else { return false }
             return size < maxImageSize
         })
     }
+}
+
+final public class ZiphySearchResultsController {
+    
+    public var ziphyClient : ZiphyClient?
 
     public var resultsLastFetch:Int {
     
@@ -56,8 +55,6 @@ import Foundation
         self.pageSize = pageSize
         self.maxImageSize = maxImageSize
         self.imageCache.totalCostLimit = 1024 * 1024 * 10 // 10MB
-        
-        super.init()
     }
     
     public func search(withSearchTerm searchTerm: String, _ completion:@escaping SuccessOrErrorCallback) -> CancelableTask? {
@@ -69,7 +66,7 @@ import Foundation
                 
                 return strongSelf.ziphyClient?.search(strongSelf.callbackQueue, term: searchTerm, resultsLimit: strongSelf.pageSize, offset: offset) { [weak self] (success, ziphs, error) -> () in
                     if let strongSelf = self {
-                        strongSelf.paginationController?.updatePagination(success, ziphs: ziphs, error: error)
+                        strongSelf.paginationController?.updatePagination(success, ziphs: ziphs.filteredResults(maxImageSize: strongSelf.maxImageSize), error: error)
                     }
                 }
             }
@@ -88,7 +85,7 @@ import Foundation
                 
                 return strongSelf.ziphyClient?.trending(strongSelf.callbackQueue, resultsLimit: strongSelf.pageSize, offset: offset) { [weak self] (success, ziphs, error) in
                     if let strongSelf = self {
-                        strongSelf.paginationController?.updatePagination(success, ziphs: ziphs, error: error)
+                        strongSelf.paginationController?.updatePagination(success, ziphs: ziphs.filteredResults(maxImageSize: strongSelf.maxImageSize), error: error)
                     }
                 }
             }


### PR DESCRIPTION
## What's new in this PR?

Add ziphs array to SuccessOrErrorCallback to prevert the UI directly access paginationController.ziphs. It fixes the UI (a collection view) out of sync issue which may cause a crash.