### PR TITLE
Fix/zios 9807 return ziphs in callback

### DIFF
--- a/ziphy/ZiphyPaginationController.swift
+++ b/ziphy/ZiphyPaginationController.swift
@@ -25,7 +25,7 @@ public typealias FetchBlock = (_ offset:Int)-> CancelableTask?
 
 public class ZiphyPaginationController {
     
-    fileprivate(set) open var ziphs:[Ziph] = []
+    fileprivate(set) var ziphs:[Ziph] = []
     
     fileprivate (set) var ziphsThisFetch = 0
     fileprivate (set) open var totalPagesFetched = 0
@@ -33,12 +33,6 @@ public class ZiphyPaginationController {
     
     open var fetchBlock:FetchBlock?
     open var completionBlock:SuccessOrErrorCallback?
-    open var callBackQueue:DispatchQueue
-    
-    public init(callBackQueue:DispatchQueue = DispatchQueue.main){
-        
-        self.callBackQueue = callBackQueue;
-    }
     
     open func fetchNewPage() -> CancelableTask? {
         

--- a/ziphy/ZiphyPaginationController.swift
+++ b/ziphy/ZiphyPaginationController.swift
@@ -20,7 +20,7 @@
 import Foundation
 
 
-public typealias SuccessOrErrorCallback = (_ success:Bool, _ error:Error?)->()
+public typealias SuccessOrErrorCallback = (_ success:Bool, _ ziphs:[Ziph], _ error:Error?)->()
 public typealias FetchBlock = (_ offset:Int)-> CancelableTask?
 
 public class ZiphyPaginationController {
@@ -72,8 +72,6 @@ public class ZiphyPaginationController {
             self.offset = self.ziphs.count
         }
         
-        performOnQueue(self.callBackQueue){
-            self.completionBlock?(success, error)
-        }
+        self.completionBlock?(success, self.ziphs, error)
     }
 }

--- a/ziphy/ZiphyPaginationController.swift
+++ b/ziphy/ZiphyPaginationController.swift
@@ -33,6 +33,8 @@ public class ZiphyPaginationController {
     
     open var fetchBlock:FetchBlock?
     open var completionBlock:SuccessOrErrorCallback?
+
+    public init() {}
     
     open func fetchNewPage() -> CancelableTask? {
         

--- a/ziphy/ZiphySearchResultsController.swift
+++ b/ziphy/ZiphySearchResultsController.swift
@@ -66,7 +66,7 @@ final public class ZiphySearchResultsController {
                 
                 return strongSelf.ziphyClient?.search(strongSelf.callbackQueue, term: searchTerm, resultsLimit: strongSelf.pageSize, offset: offset) { [weak self] (success, ziphs, error) -> () in
                     if let strongSelf = self {
-                        strongSelf.paginationController?.updatePagination(success, ziphs: ziphs.filteredResults(maxImageSize: strongSelf.maxImageSize), error: error)
+                        strongSelf.updatePagination(success, ziphs, error)
                     }
                 }
             }
@@ -85,7 +85,7 @@ final public class ZiphySearchResultsController {
                 
                 return strongSelf.ziphyClient?.trending(strongSelf.callbackQueue, resultsLimit: strongSelf.pageSize, offset: offset) { [weak self] (success, ziphs, error) in
                     if let strongSelf = self {
-                        strongSelf.paginationController?.updatePagination(success, ziphs: ziphs.filteredResults(maxImageSize: strongSelf.maxImageSize), error: error)
+                        strongSelf.updatePagination(success, ziphs, error)
                     }
                 }
             }
@@ -95,7 +95,11 @@ final public class ZiphySearchResultsController {
         
         return fetchMoreResults(completion)
     }
-    
+
+    func updatePagination(_ success:Bool, _ ziphs:[Ziph], _ error:Error?) {
+        paginationController?.updatePagination(success, ziphs: ziphs.filteredResults(maxImageSize: maxImageSize), error: error)
+    }
+
     public func fetchMoreResults(_ completion:@escaping SuccessOrErrorCallback) -> CancelableTask? {
         self.paginationController?.completionBlock = completion
         return self.paginationController?.fetchNewPage()

--- a/ziphy/ZiphySearchResultsController.swift
+++ b/ziphy/ZiphySearchResultsController.swift
@@ -59,7 +59,7 @@ final public class ZiphySearchResultsController {
     
     public func search(withSearchTerm searchTerm: String, _ completion:@escaping SuccessOrErrorCallback) -> CancelableTask? {
         
-        self.paginationController = ZiphyPaginationController(callBackQueue:callbackQueue)
+        self.paginationController = ZiphyPaginationController()
         self.paginationController?.fetchBlock = { [weak self] (offset) in
             
             if let strongSelf = self {
@@ -78,7 +78,7 @@ final public class ZiphySearchResultsController {
     }
     
     public func trending(_ completion:@escaping SuccessOrErrorCallback) -> CancelableTask? {
-        self.paginationController = ZiphyPaginationController(callBackQueue:callbackQueue)
+        self.paginationController = ZiphyPaginationController()
         self.paginationController?.fetchBlock = { [weak self] (offset) in
             
             if let strongSelf = self {

--- a/ziphy/ZiphySearchResultsController.swift
+++ b/ziphy/ZiphySearchResultsController.swift
@@ -19,19 +19,18 @@
 
 import Foundation
 
-
-
-@objc public class ZiphySearchResultsController : NSObject {
-    
-    public var ziphyClient : ZiphyClient?
-    public var results : [Ziph] {
-        let ziphs = self.paginationController?.ziphs ?? []
-        
-        return ziphs.filter({
+extension Array where Element:Ziph {
+    fileprivate func filteredResults(maxImageSize: Int) -> [Ziph] {
+        return self.filter({
             guard let size = $0.ziphyImages[ZiphyClient.fromZiphyImageTypeToString(.downsized)]?.size else { return false }
             return size < maxImageSize
         })
     }
+}
+
+final public class ZiphySearchResultsController {
+    
+    public var ziphyClient : ZiphyClient?
 
     public var resultsLastFetch:Int {
     
@@ -56,8 +55,6 @@ import Foundation
         self.pageSize = pageSize
         self.maxImageSize = maxImageSize
         self.imageCache.totalCostLimit = 1024 * 1024 * 10 // 10MB
-        
-        super.init()
     }
     
     public func search(withSearchTerm searchTerm: String, _ completion:@escaping SuccessOrErrorCallback) -> CancelableTask? {
@@ -69,7 +66,7 @@ import Foundation
                 
                 return strongSelf.ziphyClient?.search(strongSelf.callbackQueue, term: searchTerm, resultsLimit: strongSelf.pageSize, offset: offset) { [weak self] (success, ziphs, error) -> () in
                     if let strongSelf = self {
-                        strongSelf.paginationController?.updatePagination(success, ziphs: ziphs, error: error)
+                        strongSelf.paginationController?.updatePagination(success, ziphs: ziphs.filteredResults(maxImageSize: strongSelf.maxImageSize), error: error)
                     }
                 }
             }
@@ -88,7 +85,7 @@ import Foundation
                 
                 return strongSelf.ziphyClient?.trending(strongSelf.callbackQueue, resultsLimit: strongSelf.pageSize, offset: offset) { [weak self] (success, ziphs, error) in
                     if let strongSelf = self {
-                        strongSelf.paginationController?.updatePagination(success, ziphs: ziphs, error: error)
+                        strongSelf.paginationController?.updatePagination(success, ziphs: ziphs.filteredResults(maxImageSize: strongSelf.maxImageSize), error: error)
                     }
                 }
             }

--- a/ziphyTests/ZiphyPaginationControllerTests.swift
+++ b/ziphyTests/ZiphyPaginationControllerTests.swift
@@ -56,12 +56,12 @@ class ZiphyPaginationControllerTests: ZiphyTestCase {
         
         let expectation = self.expectation(description: "That a page is fetched")
 
-        let completionBlock:SuccessOrErrorCallback = { [weak paginationController](success, error) in
+        let completionBlock:SuccessOrErrorCallback = { [weak paginationController](success, ziphs, error) in
             
             expectation.fulfill()
             
             if (success) {
-                XCTAssertTrue(paginationController!.ziphs.count > 0 , "Paged fetched but no ziphs")
+                XCTAssertTrue(ziphs.count > 0 , "Paged fetched but no ziphs")
             }
             else {
                 
@@ -82,14 +82,14 @@ class ZiphyPaginationControllerTests: ZiphyTestCase {
         let expectation = self.expectation(description: "That several pages are fetched")
         
         self.paginationController.fetchBlock = self.fetchBlockForSearch(self.paginationController, searchTerm: "cat", resultsLimit: 25)
-        self.paginationController.completionBlock = { [weak self](success, error) in
+        self.paginationController.completionBlock = { [weak self](success, ziphs, error) in
             
             if (success && (self?.paginationController.totalPagesFetched)! < 3) {
                 _ = self?.paginationController.fetchNewPage()
             }
             else if (success && self?.paginationController.totalPagesFetched == 3) {
                 expectation.fulfill()
-                XCTAssertTrue(self?.paginationController.ziphs.count == 25*3, "Did not fetch enough gifs")
+                XCTAssertTrue(ziphs.count == 25*3, "Did not fetch enough gifs")
             }
             else {
                 expectation.fulfill()
@@ -107,7 +107,7 @@ class ZiphyPaginationControllerTests: ZiphyTestCase {
         let expectation = self.expectation(description: "That several pages are fetched")
         
         self.paginationController.fetchBlock = self.fetchBlockForSearch(self.paginationController, searchTerm: "awg", resultsLimit: 10)
-        self.paginationController.completionBlock = { [weak self](success, error) in
+        self.paginationController.completionBlock = { [weak self](success, ziphs, error) in
             
             if (success) {
                 _ = self?.paginationController.fetchNewPage()


### PR DESCRIPTION
## What's new in this PR?

Add ziphs array to SuccessOrErrorCallback to prevert the UI directly access paginationController.ziphs. It fixes the UI (a collection view) out of sync issue which may cause a crash.