### PR TITLE
fix: handle the case the ziph does not have preview-gif KVP

### DIFF
--- a/Sources/Model/Ziph.swift
+++ b/Sources/Model/Ziph.swift
@@ -28,7 +28,7 @@ public struct Ziph: Codable {
     public let images: ZiphyAnimatedImageList
     public let title: String?
 
-    // Some zpih do not have preview-gif KVP, use original instead
+    // Some ziph do not have preview-gif KVP, use original instead
     public var previewImage: ZiphyAnimatedImage? {
         if let image = images[.preview] {
             return image

--- a/Sources/Model/Ziph.swift
+++ b/Sources/Model/Ziph.swift
@@ -34,8 +34,10 @@ public struct Ziph: Codable {
             return image
         }
 
-        if let image = images[.original] {
-            return image
+        for imageType in ZiphyImageType.previewFallbackList {
+            if let image = images[imageType] {
+                return image
+            }
         }
 
         return nil

--- a/Sources/Model/Ziph.swift
+++ b/Sources/Model/Ziph.swift
@@ -28,6 +28,20 @@ public struct Ziph: Codable {
     public let images: ZiphyAnimatedImageList
     public let title: String?
 
+    // Some zpih do not have preview-gif KVP, use original instead
+    public var previewImage: ZiphyAnimatedImage? {
+        if let image = images[.preview] {
+            return image
+        }
+
+        if let image = images[.original] {
+            return image
+        }
+
+        return nil
+    }
+
+
     public var description: String {
         return "identifier: \(self.identifier)\n" +
         "title: \(self.title ?? "nil")\n" +

--- a/Sources/Model/ZiphyImageType.swift
+++ b/Sources/Model/ZiphyImageType.swift
@@ -38,3 +38,9 @@ public enum ZiphyImageType: String, CodingKey {
     case preview = "preview_gif"
 
 }
+
+extension ZiphyImageType {
+    static var previewFallbackList: [ZiphyImageType] {
+        return [.fixedWidthDownsampled, .fixedWidth, .downsized, .original]
+    }
+}

--- a/Ziphy.xcodeproj/project.pbxproj
+++ b/Ziphy.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		DBF380651B15C0B800369FB7 /* Ziphy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBF380591B15C0B800369FB7 /* Ziphy.framework */; };
 		DBF380761B15C2D700369FB7 /* ZiphyClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF380751B15C2D700369FB7 /* ZiphyClient.swift */; };
 		DBF3807B1B15D32C00369FB7 /* ZiphyAnimatedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBF3807A1B15D32C00369FB7 /* ZiphyAnimatedImage.swift */; };
+		EF2B16A421071D11007572DA /* ZiphyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2B16A321071D11007572DA /* ZiphyTests.swift */; };
+		EF2B16A62107247E007572DA /* ZiphHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2B16A52107247E007572DA /* ZiphHelper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -90,6 +92,8 @@
 		DBF3806A1B15C0B800369FB7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DBF380751B15C2D700369FB7 /* ZiphyClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZiphyClient.swift; sourceTree = "<group>"; };
 		DBF3807A1B15D32C00369FB7 /* ZiphyAnimatedImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZiphyAnimatedImage.swift; sourceTree = "<group>"; };
+		EF2B16A321071D11007572DA /* ZiphyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZiphyTests.swift; sourceTree = "<group>"; };
+		EF2B16A52107247E007572DA /* ZiphHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZiphHelper.swift; sourceTree = "<group>"; };
 		EFEFAD1D206B8BF50046724E /* ZiphySearchResultsControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZiphySearchResultsControllerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -255,6 +259,8 @@
 				5EF5CDB520F1EA3100CC98B0 /* ZiphyClientTests.swift */,
 				DB289BA21B6B78C000718F19 /* ZiphyPaginationControllerTests.swift */,
 				EFEFAD1D206B8BF50046724E /* ZiphySearchResultsControllerTests.swift */,
+				EF2B16A321071D11007572DA /* ZiphyTests.swift */,
+				EF2B16A52107247E007572DA /* ZiphHelper.swift */,
 				DBF380691B15C0B800369FB7 /* Supporting Files */,
 			);
 			path = ZiphyTests;
@@ -338,7 +344,7 @@
 					};
 				};
 			};
-			buildConfigurationList = DBF380531B15C0B800369FB7 /* Build configuration list for PBXProject "Ziphy" */;
+			buildConfigurationList = DBF380531B15C0B800369FB7 /* Build configuration list for PBXProject "ziphy" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -403,11 +409,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EF2B16A421071D11007572DA /* ZiphyTests.swift in Sources */,
 				5EF4A6DB20F3A9B800A9EF22 /* MockPaginatedRequester.swift in Sources */,
 				5EF4A6D720F3A06200A9EF22 /* ZiphyPaginationControllerTests.swift in Sources */,
 				5EF5CDBA20F1FF9200CC98B0 /* ZiphyClientTests.swift in Sources */,
 				5EF4A6D820F3A97400A9EF22 /* ZiphySearchResultsControllerTests.swift in Sources */,
 				5EF5CDB820F1F99100CC98B0 /* ZiphyRequestGeneratorTests.swift in Sources */,
+				EF2B16A62107247E007572DA /* ZiphHelper.swift in Sources */,
 				5EF5CDB420F1E9A900CC98B0 /* MockZiphyRequester.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -606,7 +614,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		DBF380531B15C0B800369FB7 /* Build configuration list for PBXProject "Ziphy" */ = {
+		DBF380531B15C0B800369FB7 /* Build configuration list for PBXProject "ziphy" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				DBF3806D1B15C0B800369FB7 /* Debug */,

--- a/ZiphyTests/ZiphHelper.swift
+++ b/ZiphyTests/ZiphHelper.swift
@@ -28,6 +28,11 @@ final class ZiphHelper {
             .downsized: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 5000000),
             ]
 
+        return createZiph(id: id, url: url, imagesList: imagesList)
+    }
+
+    class func createZiph(id: String, url: URL, imagesList: [ZiphyImageType: ZiphyAnimatedImage]) -> Ziph {
+
         let ziph = Ziph(identifier: id, images: ZiphyAnimatedImageList(images: imagesList), title: id)
 
         return ziph

--- a/ZiphyTests/ZiphHelper.swift
+++ b/ZiphyTests/ZiphHelper.swift
@@ -1,0 +1,35 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+@testable import Ziphy
+
+final class ZiphHelper {
+    class func createZiph(id: String, url: URL) -> Ziph {
+        let imagesList: [ZiphyImageType: ZiphyAnimatedImage] = [
+            .preview: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 51200),
+            .fixedWidthDownsampled: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 204800),
+            .original: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 2048000),
+            .downsized: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 5000000),
+            ]
+
+        let ziph = Ziph(identifier: id, images: ZiphyAnimatedImageList(images: imagesList), title: id)
+
+        return ziph
+    }
+}

--- a/ZiphyTests/ZiphySearchResultsControllerTests.swift
+++ b/ZiphyTests/ZiphySearchResultsControllerTests.swift
@@ -235,15 +235,7 @@ class ZiphySearchResultsControllerTests: XCTestCase {
         for i in 0 ..< count {
             let id = String(i)
             let url = URL(string: "http://localhost/media/image\(id).gif")!
-
-            let imagesList: [ZiphyImageType: ZiphyAnimatedImage] = [
-                .preview: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 51200),
-                .fixedWidthDownsampled: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 204800),
-                .original: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 2048000),
-                .downsized: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 5000000),
-            ]
-
-            let ziph = Ziph(identifier: id, images: ZiphyAnimatedImageList(images: imagesList), title: id)
+            let ziph = ZiphHelper.createZiph(id: id, url: url)
             ziphs.append(ziph)
         }
 

--- a/ZiphyTests/ZiphyTests.swift
+++ b/ZiphyTests/ZiphyTests.swift
@@ -39,17 +39,62 @@ final class ZiphTests: XCTestCase {
         XCTAssert(true, file: file, line: line)
     }
 
-    func testThatPreviewImageReturnsPreviewValue(){
+    func testThatPreviewImageReturnsPreviewValue() {
         // GIVEN
         let id = String(1)
         let url = URL(string: "http://localhost/media/image\(id).gif")!
         sut = ZiphHelper.createZiph(id: id, url: url)
 
-
-        // WHEN
-
-        // THEN
+        // WHEN & THEN
         let previewImage = sut.images[.preview]
         XCTAssertEqual(sut.previewImage?.description, previewImage?.description)
+    }
+
+    func testThatPreviewImageReturnsFallbackIfNoPreviewValue() {
+        // GIVEN
+        let id = String(1)
+        let url = URL(string: "http://localhost/media/image\(id).gif")!
+
+        let imagesList: [ZiphyImageType: ZiphyAnimatedImage] = [
+            .fixedWidthDownsampled: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 204800),
+            .original: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 2048000),
+            .downsized: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 5000000),
+            ]
+
+        sut = ZiphHelper.createZiph(id: id, url: url, imagesList: imagesList)
+
+        // WHEN & THEN
+        let previewImage = sut.images[.fixedWidthDownsampled]
+        XCTAssertEqual(sut.previewImage?.description, previewImage?.description)
+    }
+
+    func testThatPreviewImageReturnsOriginalCase() {
+        // GIVEN
+        let id = String(1)
+        let url = URL(string: "http://localhost/media/image\(id).gif")!
+
+        let imagesList: [ZiphyImageType: ZiphyAnimatedImage] = [
+            .original: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 2048000)
+        ]
+
+        sut = ZiphHelper.createZiph(id: id, url: url, imagesList: imagesList)
+
+        // WHEN & THEN
+        let previewImage = sut.images[.original]
+        XCTAssertEqual(sut.previewImage?.description, previewImage?.description)
+    }
+
+    func testThatPreviewImageReturnsNilCase() {
+        // GIVEN
+        let id = String(1)
+        let url = URL(string: "http://localhost/media/image\(id).gif")!
+
+        let imagesList: [ZiphyImageType: ZiphyAnimatedImage] = [:]
+
+        sut = ZiphHelper.createZiph(id: id, url: url, imagesList: imagesList)
+
+        // WHEN & THEN
+        let nilImage: ZiphyAnimatedImage? = nil
+        XCTAssertEqual(sut.previewImage?.description, nilImage?.description)
     }
 }

--- a/ZiphyTests/ZiphyTests.swift
+++ b/ZiphyTests/ZiphyTests.swift
@@ -1,0 +1,55 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import Ziphy
+
+final class ZiphTests: XCTestCase {
+    
+    var sut: Ziph!
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+
+
+    /// Example checker method which can be reused in different tests
+    fileprivate func checkerExample(file: StaticString = #file, line: UInt = #line) {
+        XCTAssert(true, file: file, line: line)
+    }
+
+    func testThatPreviewImageReturnsPreviewValue(){
+        // GIVEN
+        let id = String(1)
+        let url = URL(string: "http://localhost/media/image\(id).gif")!
+        sut = ZiphHelper.createZiph(id: id, url: url)
+
+
+        // WHEN
+
+        // THEN
+        let previewImage = sut.images[.preview]
+        XCTAssertEqual(sut.previewImage?.description, previewImage?.description)
+    }
+}


### PR DESCRIPTION
## What's new in this PR?

Some Ziph has no value for the key "preview-gif". (Maybe the GIF is small and the preview is not necessary) In that case, return the original image instead. 