### PR TITLE
[Chore] Migrate to Xcode 11.3

### DIFF
--- a/Resources/Configurations/zmc-config/project-common.xcconfig
+++ b/Resources/Configurations/zmc-config/project-common.xcconfig
@@ -53,7 +53,7 @@ DYLIB_CURRENT_VERSION = $(CURRENT_PROJECT_VERSION)
 
 // Swift
 //
-SWIFT_VERSION = 5.0
+SWIFT_VERSION = 5.1
 ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
 SWIFT_COMPILATION_MODE = wholemodule
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @loader_path/Frameworks @loader_path/../Frameworks @executable_path/Frameworks @executable_path/../Frameworks

--- a/Resources/Configurations/zmc-config/project-common.xcconfig
+++ b/Resources/Configurations/zmc-config/project-common.xcconfig
@@ -1,6 +1,6 @@
 //
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
+// Copyright (C) 2020 Wire Swiss GmbH
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Ziphy.xcodeproj/project.pbxproj
+++ b/Ziphy.xcodeproj/project.pbxproj
@@ -329,7 +329,7 @@
 			attributes = {
 				LastSwiftMigration = 0710;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 1000;
+				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = "Zeta Project Germany";
 				TargetAttributes = {
 					DBF380581B15C0B800369FB7 = {
@@ -342,13 +342,13 @@
 					};
 				};
 			};
-			buildConfigurationList = DBF380531B15C0B800369FB7 /* Build configuration list for PBXProject "ziphy" */;
+			buildConfigurationList = DBF380531B15C0B800369FB7 /* Build configuration list for PBXProject "Ziphy" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
+				Base,
 			);
 			mainGroup = DBF3804F1B15C0B800369FB7;
 			productRefGroup = DBF3805A1B15C0B800369FB7 /* Products */;
@@ -435,6 +435,7 @@
 			baseConfigurationReference = 54FB26861D4669D0005574BF /* project-debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -492,6 +493,7 @@
 			baseConfigurationReference = 54FB26861D4669D0005574BF /* project-debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -541,6 +543,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 54FB265A1D4669A6005574BF /* ziphy-ios.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -554,6 +557,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 54FB265A1D4669A6005574BF /* ziphy-ios.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -590,7 +594,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		DBF380531B15C0B800369FB7 /* Build configuration list for PBXProject "ziphy" */ = {
+		DBF380531B15C0B800369FB7 /* Build configuration list for PBXProject "Ziphy" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				DBF3806D1B15C0B800369FB7 /* Debug */,

--- a/Ziphy.xcodeproj/xcshareddata/xcschemes/Ziphy.xcscheme
+++ b/Ziphy.xcodeproj/xcshareddata/xcschemes/Ziphy.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,9 +26,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DBF380581B15C0B800369FB7"
+            BuildableName = "Ziphy.framework"
+            BlueprintName = "Ziphy"
+            ReferencedContainer = "container:Ziphy.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -50,17 +59,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DBF380581B15C0B800369FB7"
-            BuildableName = "Ziphy.framework"
-            BlueprintName = "Ziphy"
-            ReferencedContainer = "container:Ziphy.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -81,8 +79,6 @@
             ReferencedContainer = "container:Ziphy.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ resources:
   - repository: wire-ios-shared-resources
     type: github
     name: wireapp/wire-ios-shared-resources
-    ref: refs/heads/master # Branch to fetch the jobs template from
+    ref: refs/heads/chore/xcode11.3 # Branch to fetch the jobs template from
     endpoint: wireapp
 
 trigger:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ resources:
   - repository: wire-ios-shared-resources
     type: github
     name: wireapp/wire-ios-shared-resources
-    ref: refs/heads/chore/xcode11.3 # Branch to fetch the jobs template from
+    ref: refs/heads/master # Branch to fetch the jobs template from
     endpoint: wireapp
 
 trigger:


### PR DESCRIPTION
## What's new in this PR?

This PR includes changes to migrate from Xcode 10.2.3 to Xcode 11.3. Changes include:

- update to recommended project settings

### Needs Release With

- [x] https://github.com/wireapp/wire-ios-shared-resources/pull/39

### To Do

- [x] Unpin azure pipeline

### Notes

Zero build warnings 🎉 
