### PR TITLE
remove ZiphyURLRequester @objc signature

### DIFF
--- a/Sources/Utilities/ZiphyUtils.swift
+++ b/Sources/Utilities/ZiphyUtils.swift
@@ -53,7 +53,7 @@ public protocol CancelableTask {
  * An object that performs network requests to the Giphy API.
  */
 
-@objc public protocol ZiphyURLRequester {
+public protocol ZiphyURLRequester {
     
     func performZiphyRequest(_ request: URLRequest, completionHandler: @escaping ((Data?, URLResponse?, Error?) -> Void)) -> ZiphyRequestIdentifier
 


### PR DESCRIPTION
## What's new in this PR?

Remove @objc signature to fix building XCFramework issue on UI project