### PR TITLE
Remove swift library reduce framework size

### DIFF
--- a/Resources/Configurations/zmc-config/project-common.xcconfig
+++ b/Resources/Configurations/zmc-config/project-common.xcconfig
@@ -45,8 +45,8 @@ FRAMEWORK_VERSION = A
 // Linking
 //
 OTHER_LDFLAGS = -ObjC
-CARTHAGE_FOLDER[sdk=iphoneos*] = $(PROJECT_DIR)/Carthage/Build/iOS
-CARTHAGE_FOLDER[sdk=iphonesimulator*] = $(PROJECT_DIR)/Carthage/Build/iOS
+CARTHAGE_FOLDER[sdk=iphoneos*] = $(PROJECT_DIR)/Carthage/Build
+CARTHAGE_FOLDER[sdk=iphonesimulator*] = $(PROJECT_DIR)/Carthage/Build
 FRAMEWORK_SEARCH_PATHS = $(inherited) $(CARTHAGE_FOLDER) $(PLATFORM_DIR)/Developer/Library/Frameworks
 DYLIB_COMPATIBILITY_VERSION = $(MAJOR_VERSION).0
 DYLIB_CURRENT_VERSION = $(CURRENT_PROJECT_VERSION)
@@ -54,7 +54,7 @@ DYLIB_CURRENT_VERSION = $(CURRENT_PROJECT_VERSION)
 // Swift
 //
 SWIFT_VERSION = 5.1
-ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
+ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO
 SWIFT_COMPILATION_MODE = wholemodule
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @loader_path/Frameworks @loader_path/../Frameworks @executable_path/Frameworks @executable_path/../Frameworks
 DEFINES_MODULE = YES


### PR DESCRIPTION
## What's new in this PR?

set ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO to remove unnecessary swift library in package.

also this would cause error when submitting to app store

`ERROR ITMS-90206: "Invalid Bundle. The bundle at 'Wire.app/Frameworks/Ziphy.framework' contains disallowed file 'Frameworks'."`