### PR TITLE
fix: SwiftLint warnings for `opening_brace`, `colon`, `trailing_whitespace`, `redundant_nil_coalescing`, `comma_referencing`

### DIFF
--- a/Sources/Client/ZiphyClient.swift
+++ b/Sources/Client/ZiphyClient.swift
@@ -74,7 +74,7 @@ extension ZiphyClient {
 
     @discardableResult
     public func fetchTrending(resultsLimit: Int = 25, offset: Int, onCompletion: @escaping ZiphyListRequestCallback) -> CancelableTask? {
-        
+
         let request = requestGenerator.makeTrendingImagesRequest(resultsLimit: resultsLimit, offset: offset)
         return performPotentialZiphListRequest(request, onCompletion: onCompletion)
     }
@@ -92,11 +92,11 @@ extension ZiphyClient {
 
     @discardableResult
     public func search(term: String, resultsLimit: Int = 25, offset: Int = 0, onCompletion: @escaping ZiphyListRequestCallback) -> CancelableTask? {
-        
+
         let request = requestGenerator.makeSearchRequest(term: term, resultsLimit: resultsLimit, offset: offset)
         return performPotentialZiphListRequest(request, onCompletion: onCompletion)
     }
-    
+
     private func performPotentialZiphListRequest(_ potentialRequest: ZiphyResult<URLRequest>, isPaginated: Bool = true, onCompletion: @escaping ZiphyListRequestCallback) -> CancelableTask? {
 
         let completionHandler = makeCompletionHandler(onCompletion)
@@ -212,7 +212,7 @@ extension ZiphyClient {
     }
 
     /// Creates and schedules a request for the given URL request and returns the promise to its reponse.
-    fileprivate func performDataTask(_ request:URLRequest, requester:ZiphyURLRequester) -> URLRequestPromise {
+    fileprivate func performDataTask(_ request: URLRequest, requester: ZiphyURLRequester) -> URLRequestPromise {
         let promise = URLRequestPromise(requester: requester)
         let requestIdentifier = requester.performZiphyRequest(request, completionHandler: promise.resolve)
 

--- a/Sources/Client/ZiphyError.swift
+++ b/Sources/Client/ZiphyError.swift
@@ -37,5 +37,5 @@ public enum ZiphyError: Error {
     init(_ error: Error) {
         self = (error as? ZiphyError) ?? .unknownError(error)
     }
-    
+
 }

--- a/Sources/Client/ZiphyPaginationController.swift
+++ b/Sources/Client/ZiphyPaginationController.swift
@@ -46,14 +46,14 @@ class ZiphyPaginationController {
 
     // MARK: - Updating the Data
 
-    private func fetchNewPage(_ offset:Int) -> CancelableTask? {
+    private func fetchNewPage(_ offset: Int) -> CancelableTask? {
         guard !isAtEnd else {
             return nil
         }
 
         return self.fetchBlock?(offset)
     }
-    
+
     func updatePagination(_ result: ZiphyResult<[Ziph]>, filter: ((Ziph) -> Bool)?) {
         switch result {
         case .success(let insertedZiphs):

--- a/Sources/Model/Ziph.swift
+++ b/Sources/Model/Ziph.swift
@@ -43,7 +43,6 @@ public struct Ziph: Codable {
         return nil
     }
 
-
     public var description: String {
         return "identifier: \(self.identifier)\n" +
         "title: \(self.title ?? "nil")\n" +

--- a/Sources/Model/ZiphyAnimatedImageList.swift
+++ b/Sources/Model/ZiphyAnimatedImageList.swift
@@ -58,7 +58,7 @@ public struct ZiphyAnimatedImageList: Codable {
 
 extension ZiphyAnimatedImageList: Sequence {
 
-    public typealias RawValue = Dictionary<ZiphyImageType, ZiphyAnimatedImage>
+    public typealias RawValue = [ZiphyImageType: ZiphyAnimatedImage]
 
     /// Returns the image for the specified type.
     public subscript(type: ZiphyImageType) -> ZiphyAnimatedImage? {

--- a/Sources/Utilities/URLRequestPromise.swift
+++ b/Sources/Utilities/URLRequestPromise.swift
@@ -79,7 +79,7 @@ class URLRequestPromise: CancelableTask {
 
     private var isCancelled: Bool = false
     private var isResolved: Bool = false
-    private var result: (Data?, URLResponse?, Error?)? = nil
+    private var result: (Data?, URLResponse?, Error?)?
     private var failureError: ZiphyError?
 
     /**

--- a/Sources/Utilities/ZiphyUtils.swift
+++ b/Sources/Utilities/ZiphyUtils.swift
@@ -54,9 +54,8 @@ public protocol CancelableTask {
  */
 
 public protocol ZiphyURLRequester {
-    
-    func performZiphyRequest(_ request: URLRequest, completionHandler: @escaping ((Data?, URLResponse?, Error?) -> Void)) -> ZiphyRequestIdentifier
 
+    func performZiphyRequest(_ request: URLRequest, completionHandler: @escaping ((Data?, URLResponse?, Error?) -> Void)) -> ZiphyRequestIdentifier
 
     func cancelZiphyRequest(withRequestIdentifier requestIdentifier: ZiphyRequestIdentifier)
 

--- a/ZiphyTests/Mocks/MockPaginatedRequester.swift
+++ b/ZiphyTests/Mocks/MockPaginatedRequester.swift
@@ -32,7 +32,7 @@ class MockPaginatedRequester: ZiphyURLRequester {
 
     private var offset: Int = 0
     private var limit: Int = 0
-    private var url: URL? = nil
+    private var url: URL?
 
     var response: MockPaginatedResponse?
 

--- a/ZiphyTests/ZiphHelper.swift
+++ b/ZiphyTests/ZiphHelper.swift
@@ -25,7 +25,7 @@ final class ZiphHelper {
             .preview: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 51200),
             .fixedWidthDownsampled: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 204800),
             .original: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 2048000),
-            .downsized: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 5000000),
+            .downsized: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 5000000)
             ]
 
         return createZiph(id: id, url: url, imagesList: imagesList)

--- a/ZiphyTests/ZiphyClientTests.swift
+++ b/ZiphyTests/ZiphyClientTests.swift
@@ -42,7 +42,7 @@ class ZiphyClientTests: XCTestCase {
 
         // WHEN
         let fetchExpectation = expectation(description: "The resource can be fetched and decoded.")
-        var result: ZiphyResult<Ziph>? = nil
+        var result: ZiphyResult<Ziph>?
 
         client.fetchRandomPost {
             result = $0
@@ -75,7 +75,7 @@ class ZiphyClientTests: XCTestCase {
 
         // WHEN
         let fetchExpectation = expectation(description: "The resource can be fetched and decoded.")
-        var result: ZiphyResult<[Ziph]>? = nil
+        var result: ZiphyResult<[Ziph]>?
 
         client.search(term: "judge judy") {
             result = $0
@@ -106,7 +106,7 @@ class ZiphyClientTests: XCTestCase {
 
         // WHEN
         let fetchExpectation = expectation(description: "The resource can be fetched and decoded.")
-        var result: ZiphyResult<[Ziph]>? = nil
+        var result: ZiphyResult<[Ziph]>?
 
         client.search(term: "judge judy") {
             result = $0

--- a/ZiphyTests/ZiphyPaginationControllerTests.swift
+++ b/ZiphyTests/ZiphyPaginationControllerTests.swift
@@ -22,12 +22,12 @@ import XCTest
 class ZiphyPaginationControllerTests: XCTestCase {
 
     var paginationController: ZiphyPaginationController!
-    
+
     override func setUp() {
         super.setUp()
         paginationController = ZiphyPaginationController()
     }
-    
+
     override func tearDown() {
         paginationController = nil
         super.tearDown()

--- a/ZiphyTests/ZiphySearchResultsControllerTests.swift
+++ b/ZiphyTests/ZiphySearchResultsControllerTests.swift
@@ -162,7 +162,7 @@ class ZiphySearchResultsControllerTests: XCTestCase {
         // WHEN
         let fetchExpectation = expectation(description: "Initial trending images are fetched.")
 
-        _ = searchController.trending { result in
+        _ = searchController.trending { _ in
             fetchExpectation.fulfill()
         }
 

--- a/ZiphyTests/ZiphyTests.swift
+++ b/ZiphyTests/ZiphyTests.swift
@@ -20,19 +20,17 @@ import XCTest
 @testable import Ziphy
 
 final class ZiphTests: XCTestCase {
-    
+
     var sut: Ziph!
-    
+
     override func setUp() {
         super.setUp()
     }
-    
+
     override func tearDown() {
         sut = nil
         super.tearDown()
     }
-
-
 
     /// Example checker method which can be reused in different tests
     fileprivate func checkerExample(file: StaticString = #file, line: UInt = #line) {
@@ -58,7 +56,7 @@ final class ZiphTests: XCTestCase {
         let imagesList: [ZiphyImageType: ZiphyAnimatedImage] = [
             .fixedWidthDownsampled: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 204800),
             .original: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 2048000),
-            .downsized: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 5000000),
+            .downsized: ZiphyAnimatedImage(url: url, width: 300, height: 200, fileSize: 5000000)
             ]
 
         sut = ZiphHelper.createZiph(id: id, url: url, imagesList: imagesList)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR I fix warnings for the following SwiftLint rules:

- **Opening Brace Spacing Violation**: Opening braces should be preceded by a single space and on the same line as the declaration. `(opening_brace)`
- **Colon Violation**: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. `(colon)`
- **Trailing Whitespace Violation**: Lines should not have trailing whitespace. `(trailing_whitespace)`
- **Redundant Nil Coalescing**: nil coalescing operator is only evaluated if the lhs is nil, coalescing operator with nil as rhs is redundant `(redundant_nil_coalescing)`
- **Comma Spacing Violation**: There should be no space before and one after any comma. `(comma_referencing)`


----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
